### PR TITLE
Fix showing column in drop event of external drop

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
 	"author": "Michael Herrmann",
 	"license": "MIT",
 	"homepage": "https://github.com/mherrmann/fullcalendar-columns",
-	"main": "fullclendar-columns.js",
+	"main": "fullcalendar-columns.js",
 	"ignore": [
 		".*",
 		"Gemfile",

--- a/fullcalendar-columns.js
+++ b/fullcalendar-columns.js
@@ -204,7 +204,7 @@
 		},
 		_triggerExternalDrop: function(event, dropLocation, el, ev, ui) {
 			// Trigger 'drop' regardless of whether element represents an event
-			this.trigger('drop', el[0], dropLocation.start, ev, ui);
+			this.trigger('drop', el[0], dropLocation.start, ev, ui, dropLocation.column);
 			if (event)
 				this.trigger('eventReceive', null, event);
 		}


### PR DESCRIPTION
When dropping a draggable jQuery element from outside of the calendar, the column was added to the drop event so it's accessible from the callback.
